### PR TITLE
Доработка @showexp

### DIFF
--- a/conf/atcommands.yml
+++ b/conf/atcommands.yml
@@ -1259,7 +1259,9 @@ Body:
       Shows/hides the "There is a delay after this skill" message.
   - Command: showexp
     Help: |
+      Params: <time>
       Displays/hides experience gained.
+      If time parameter is provided, displays experience change per specified period.
   - Command: showmobs
     Help: |
       Params: <monster ID>

--- a/conf/login_athena.conf
+++ b/conf/login_athena.conf
@@ -49,11 +49,11 @@ console_silent: 0
 // Console Commands
 // Allow for console commands to be used on/off
 // This prevents usage of >& log.file
-console: off
+console: on
 
 // Can you use _M/_F to make new accounts on the server?
 // Note: This only works if client side password encryption is not enabled.
-new_account: no
+new_account: yes
 
 // If new_account is enabled, changes the minimum length for the account name.
 // By default is set to '4' or '6' (depending on the new login UI).
@@ -128,7 +128,7 @@ usercount_medium: 500
 usercount_high: 1000
 
 // Ipban features
-ipban_enable: yes
+ipban_enable: no
 // Dynamic password failure ipban system
 // Ban user after a number of failed attempts?
 ipban_dynamic_pass_failure_ban: yes

--- a/conf/msg_conf/map_msg.conf
+++ b/conf/msg_conf/map_msg.conf
@@ -1829,5 +1829,9 @@
 //@macrochecker
 1538: Macro detection has been started on %d players.
 
+//@showexp on timer
+1539: Gained exp is now shown every %d minutes
+1540: Experience: %s Base: %ld %s Job: %ld
+
 //Custom translations
 import: conf/msg_conf/import/map_msg_eng_conf.txt

--- a/conf/msg_conf/map_msg.conf
+++ b/conf/msg_conf/map_msg.conf
@@ -793,7 +793,7 @@
 // @showexp
 741: Gained
 742: Lost
-743: Experience Base: %s %ld (%0.2f%%) Job: %s %ld (%0.2f%%)
+743: Experience %s Base: %ld (%0.2f%%) Job: %ld (%0.2f%%)
 
 // @adopt
 744: Baby already adopted or is in the process of being adopted.

--- a/conf/msg_conf/map_msg.conf
+++ b/conf/msg_conf/map_msg.conf
@@ -793,7 +793,7 @@
 // @showexp
 741: Gained
 742: Lost
-743: Experience %s Base: %ld (%0.2f%%) Job: %ld (%0.2f%%)
+743: Experience %s Base:%ld (%0.2f%%) Job:%ld (%0.2f%%)
 
 // @adopt
 744: Baby already adopted or is in the process of being adopted.

--- a/conf/msg_conf/map_msg.conf
+++ b/conf/msg_conf/map_msg.conf
@@ -793,7 +793,7 @@
 // @showexp
 741: Gained
 742: Lost
-743: Experience %s Base:%ld (%0.2f%%) Job:%ld (%0.2f%%)
+743: Experience Base: %s %ld (%0.2f%%) Job: %s %ld (%0.2f%%)
 
 // @adopt
 744: Baby already adopted or is in the process of being adopted.

--- a/src/map/atcommand.cpp
+++ b/src/map/atcommand.cpp
@@ -9068,50 +9068,35 @@ ACMD_FUNC(showexp)
 {
 	nullpo_retr(-1, sd);
 
-	if(message && *message)
-	{
+	if(message && *message) {
 		// Has parameters
 		int32 minute_count;
-		if(sscanf(message, "%d", &minute_count) != 1)
-		{
+		if(sscanf(message, "%d", &minute_count) != 1) {
 			return -1;
-		} else if(minute_count < 1)
-		{
+		} else if(minute_count < 1) {
 			return -1;
 		}
-		t_tick new_interval = minute_count * 60 * 1000;
 
-		int32 new_timer = add_timer_interval(gettick() + new_interval, pc_showexp_timer, 0, (intptr_t)sd, new_interval);
-		if(new_timer == INVALID_TIMER)
-		{
-			return -1;
-		}
-		if(sd->showexp_state.timer != INVALID_TIMER && delete_timer(sd->showexp_state.timer, pc_showexp_timer))
-		{
-			return -1;
-		}
-		sd->showexp_state.timer = new_timer;
-		sd->showexp_state.last_base_exp = sd->status.base_exp;
-		sd->showexp_state.last_job_exp = sd->status.job_exp;
+		pc_set_showexp_timer(sd, minute_count * 60 * 1000);
+		pc_reset_accumulated_exp(sd);
+		sd->state.showexp = 1;
 
-		// Do not return here
+		char output[CHAT_SIZE_MAX] = {0};
+		sprintf(output, msg_txt(sd, 1539), minute_count); // Gained exp is now shown every %d minutes
+		clif_displaymessage(fd, output);
+		return 0;
 
 	} else if (sd->state.showexp) {
 		sd->state.showexp = 0;
 		clif_displaymessage(fd, msg_txt(sd,1316)); // Gained exp will not be shown.
-
-		if(sd->showexp_state.timer != INVALID_TIMER && delete_timer(sd->showexp_state.timer, pc_showexp_timer))
-		{
-			return -1;
-		}
+		pc_delete_showexp_timer(sd);
 		return 0;
-	}
 
-	if(!sd->state.showexp) {
+	} else {
 		sd->state.showexp = 1;
 		clif_displaymessage(fd, msg_txt(sd,1317)); // Gained exp is now shown.
+		return 0;
 	}
-	return 0;
 }
 
 ACMD_FUNC(showzeny)

--- a/src/map/pc.cpp
+++ b/src/map/pc.cpp
@@ -8318,10 +8318,10 @@ void pc_gainexp_disp(map_session_data *sd, t_exp base_exp, t_exp next_base_exp, 
 
 	nullpo_retv(sd);
 
-	sprintf(output, msg_txt(sd,743), // Experience %s Base: %ld (%0.2f%%) Job: %ld (%0.2f%%)
-		lost? msg_txt(sd, 742) : msg_txt(sd, 741),
-		(long)base_exp * (lost? -1 : 1), (base_exp / (float)next_base_exp * 100 * (lost? -1 : 1)),
-		(long)job_exp * (lost? -1 : 1), (job_exp / (float)next_job_exp * 100 * (lost? -1 : 1)));
+	sprintf(output, msg_txt(sd,743), // Experience %s Base:%ld (%0.2f%%) Job:%ld (%0.2f%%)
+		(lost) ? msg_txt(sd,742) : msg_txt(sd,741),
+		(long)base_exp * (lost ? -1 : 1), (base_exp / (float)next_base_exp * 100 * (lost ? -1 : 1)),
+		(long)job_exp * (lost ? -1 : 1), (job_exp / (float)next_job_exp * 100 * (lost ? -1 : 1)));
 	clif_messagecolor(&sd->bl, color_table[COLOR_LIGHT_GREEN], output, false, SELF);
 }
 

--- a/src/map/pc.cpp
+++ b/src/map/pc.cpp
@@ -8527,23 +8527,6 @@ void pc_delete_showexp_timer(map_session_data* sd) {
 	}
 }
 
-static inline bool pc_showexp_update_exp(t_exp* delta, t_exp* last_exp, t_exp current_exp) {
-	nullpo_retr(false, delta);
-	*delta = 0;
-
-	nullpo_retr(false, last_exp);
-
-	*delta = current_exp - *last_exp;
-	bool lost = false;
-	if(current_exp < *last_exp) {
-		lost = true;
-		*delta = -(*delta);
-	}
-	*last_exp = current_exp;
-
-	return lost;
-}
-
 TIMER_FUNC(pc_showexp_timer) {
 	map_session_data* sd = (map_session_data*)data;
 	nullpo_retr(-1, sd);

--- a/src/map/pc.cpp
+++ b/src/map/pc.cpp
@@ -8531,7 +8531,9 @@ void pc_delete_showexp_timer(map_session_data* sd) {
 
 TIMER_FUNC(pc_showexp_timer) {
 	map_session_data* sd = map_id2sd(id);
-	nullpo_ret(sd);
+	if(!sd) {
+		return 0;
+	}
 
 	if(sd->showexp_state.base_exp_delta || sd->showexp_state.job_exp_delta) {
 		pc_gainexp_disp_accumulated(sd);

--- a/src/map/pc.cpp
+++ b/src/map/pc.cpp
@@ -8515,7 +8515,8 @@ void pc_set_showexp_timer(map_session_data* sd, t_tick interval) {
 	if(sd->showexp_state.timer != INVALID_TIMER) {
 		delete_timer(sd->showexp_state.timer, pc_showexp_timer);
 	}
-	sd->showexp_state.timer = add_timer_interval(gettick() + interval, pc_showexp_timer, 0, (intptr_t)sd, interval);
+	sd->showexp_state.timer_interval = interval;
+	sd->showexp_state.timer = add_timer(gettick() + interval, pc_showexp_timer, sd->bl.id, 0);
 }
 
 void pc_delete_showexp_timer(map_session_data* sd) {
@@ -8524,12 +8525,13 @@ void pc_delete_showexp_timer(map_session_data* sd) {
 	if(sd->showexp_state.timer != INVALID_TIMER) {
 		delete_timer(sd->showexp_state.timer, pc_showexp_timer);
 		sd->showexp_state.timer = INVALID_TIMER;
+		sd->showexp_state.timer_interval = 0;
 	}
 }
 
 TIMER_FUNC(pc_showexp_timer) {
-	map_session_data* sd = (map_session_data*)data;
-	nullpo_retr(-1, sd);
+	map_session_data* sd = map_id2sd(id);
+	nullpo_ret(sd);
 
 	if(sd->showexp_state.base_exp_delta || sd->showexp_state.job_exp_delta) {
 		pc_gainexp_disp_accumulated(sd);
@@ -8537,6 +8539,7 @@ TIMER_FUNC(pc_showexp_timer) {
 
 	pc_reset_accumulated_exp(sd);
 
+	pc_set_showexp_timer(sd, sd->showexp_state.timer_interval);
 	return 0;
 }
 

--- a/src/map/pc.hpp
+++ b/src/map/pc.hpp
@@ -485,6 +485,12 @@ public:
 	int32 langtype;
 	struct mmo_charstatus status;
 
+	struct s_showexp_state {
+		int32 timer;
+		t_exp last_base_exp;
+		t_exp last_job_exp;
+	} showexp_state;
+
 	// Item Storages
 	struct s_storage storage, premiumStorage;
 	struct s_storage inventory;
@@ -1516,7 +1522,7 @@ bool pc_is_maxjoblv(map_session_data *sd);
 int32 pc_checkbaselevelup(map_session_data *sd);
 int32 pc_checkjoblevelup(map_session_data *sd);
 void pc_gainexp(map_session_data *sd, struct block_list *src, t_exp base_exp, t_exp job_exp, uint8 exp_flag);
-void pc_gainexp_disp(map_session_data *sd, t_exp base_exp, t_exp next_base_exp, t_exp job_exp, t_exp next_job_exp, bool lost);
+void pc_gainexp_disp(map_session_data *sd, t_exp base_exp, t_exp next_base_exp, t_exp job_exp, t_exp next_job_exp, bool lost_base_exp, bool lost_job_exp);
 void pc_lostexp(map_session_data *sd, t_exp base_exp, t_exp job_exp);
 t_exp pc_nextbaseexp(map_session_data *sd);
 t_exp pc_nextjobexp(map_session_data *sd);
@@ -1544,6 +1550,8 @@ void pc_equipswitch_remove( map_session_data* sd, int32 index );
 void pc_checkitem(map_session_data*);
 void pc_check_available_item(map_session_data *sd, uint8 type);
 int32 pc_useitem(map_session_data*,int32);
+
+TIMER_FUNC(pc_showexp_timer);
 
 int32 pc_skillatk_bonus(map_session_data *sd, uint16 skill_id);
 int32 pc_sub_skillatk_bonus(map_session_data *sd, uint16 skill_id);

--- a/src/map/pc.hpp
+++ b/src/map/pc.hpp
@@ -487,6 +487,7 @@ public:
 
 	struct s_showexp_state {
 		int32 timer;
+		t_tick timer_interval;
 		t_exp base_exp_delta;
 		t_exp job_exp_delta;
 		bool base_exp_delta_negative;

--- a/src/map/pc.hpp
+++ b/src/map/pc.hpp
@@ -487,8 +487,10 @@ public:
 
 	struct s_showexp_state {
 		int32 timer;
-		t_exp last_base_exp;
-		t_exp last_job_exp;
+		t_exp base_exp_delta;
+		t_exp job_exp_delta;
+		bool base_exp_delta_negative;
+		bool job_exp_delta_negative;
 	} showexp_state;
 
 	// Item Storages
@@ -1522,7 +1524,10 @@ bool pc_is_maxjoblv(map_session_data *sd);
 int32 pc_checkbaselevelup(map_session_data *sd);
 int32 pc_checkjoblevelup(map_session_data *sd);
 void pc_gainexp(map_session_data *sd, struct block_list *src, t_exp base_exp, t_exp job_exp, uint8 exp_flag);
-void pc_gainexp_disp(map_session_data *sd, t_exp base_exp, t_exp next_base_exp, t_exp job_exp, t_exp next_job_exp, bool lost_base_exp, bool lost_job_exp);
+void pc_gainexp_disp(map_session_data *sd, t_exp base_exp, t_exp next_base_exp, t_exp job_exp, t_exp next_job_exp, bool lost);
+void pc_gainexp_disp_accumulated(map_session_data* sd);
+void pc_reset_accumulated_exp(map_session_data* sd);
+void pc_update_accumulated_exp(map_session_data* sd, t_exp base_exp, t_exp job_exp, bool lost);
 void pc_lostexp(map_session_data *sd, t_exp base_exp, t_exp job_exp);
 t_exp pc_nextbaseexp(map_session_data *sd);
 t_exp pc_nextjobexp(map_session_data *sd);
@@ -1672,6 +1677,9 @@ void pc_delete_bg_queue_timer(map_session_data *sd);
 
 void pc_setinvincibletimer(map_session_data* sd, int32 val);
 void pc_delinvincibletimer(map_session_data* sd);
+
+void pc_set_showexp_timer(map_session_data* sd, t_tick interval);
+void pc_delete_showexp_timer(map_session_data* sd);
 
 void pc_addspiritball(map_session_data *sd,int32 interval,int32 max);
 void pc_delspiritball(map_session_data *sd,int32 count,int32 type);

--- a/src/map/unit.cpp
+++ b/src/map/unit.cpp
@@ -3774,6 +3774,7 @@ int32 unit_free(struct block_list *bl, clr_type clrtype)
 				pc_setrestartvalue(sd,2);
 
 			pc_delinvincibletimer(sd);
+			pc_delete_showexp_timer(sd);
 
 			pc_delautobonus(*sd, sd->autobonus, false);
 			pc_delautobonus(*sd, sd->autobonus2, false);

--- a/src/map/unit.cpp
+++ b/src/map/unit.cpp
@@ -3774,7 +3774,6 @@ int32 unit_free(struct block_list *bl, clr_type clrtype)
 				pc_setrestartvalue(sd,2);
 
 			pc_delinvincibletimer(sd);
-			pc_delete_showexp_timer(sd);
 
 			pc_delautobonus(*sd, sd->autobonus, false);
 			pc_delautobonus(*sd, sd->autobonus2, false);


### PR DESCRIPTION
**Изменения:**

- @showexp теперь принимает опциональный параметр: время в минутах (целое число)
- Если параметр присутствует, @showexp выводит изменение опыта за указанный промежуток времени (если опыт не изменился, то не выводится ничего)
- @showexp с параметром всегда запускает новый таймер (если таймер уже был установлен, он заменяется на новый)
- При ошибке парсинга параметра @showexp не меняет текущий статус команды
- Добавлены новые сообщения в conf/msg_conf/map_msg.conf
